### PR TITLE
gateway(legacy): port /get fetch pool to gateway.DefaultGateways; bump v0.18.1

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -4,7 +4,7 @@ package common
 var BinaryName = "defaultBinaryName"
 
 // Version is the version of the binary
-var Version = "v0.1.0"
+var Version = "v0.18.1"
 
 // GitCommit is the commit hash of the binary
 var GitCommit = "00000000"

--- a/internal/pinner/ipfs-node/legacy.go
+++ b/internal/pinner/ipfs-node/legacy.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/covalenthq/das-ipfs-pinner/internal/gateway"
 	iface "github.com/ipfs/kubo/core/coreiface"
 	"github.com/ipfs/kubo/core/coreiface/options"
 	mh "github.com/multiformats/go-multihash"
@@ -39,9 +41,24 @@ func (ipfsNode *IPFSNode) AddOptions(upload bool) []options.UnixfsAddOption {
 	return addOptions
 }
 
-var (
-	IPFS_HTTP_GATEWAYS = []string{"https://w3s.link/ipfs/%s", "https://dweb.link/ipfs/%s", "https://ipfs.io/ipfs/%s"}
-)
+// IPFS_HTTP_GATEWAYS is the gateway pool used by the deprecated /get
+// endpoint. It is derived from gateway.DefaultGateways (the same source of
+// truth the /api/v1/get path uses) so future updates to that pool flow
+// through automatically and the legacy path can never drift back to a
+// retired gateway. The legacy fetcher injects the CID via fmt.Sprintf, so
+// each base URL is suffixed with "/ipfs/%s".
+//
+// The optional DEDICATED_GATEWAY is intentionally not honoured here — the
+// legacy endpoint is deprecated and callers should migrate to /api/v1/get
+// to pick up dedicated-gateway support and the new path's parallel-fetch
+// worker pool.
+var IPFS_HTTP_GATEWAYS = func() []string {
+	out := make([]string, 0, len(gateway.DefaultGateways))
+	for _, g := range gateway.DefaultGateways {
+		out = append(out, strings.TrimRight(g, "/")+"/ipfs/%s")
+	}
+	return out
+}()
 
 type httpContentFetcher struct {
 	cursor        int


### PR DESCRIPTION
## Summary

Stacks on top of [#73](https://github.com/covalenthq/ewm-das/pull/73). #73 swapped the **new-path** gateway pool from `w3s.link` to `ipfs.filebase.io` in `internal/gateway/handler.go`, but the deprecated `/get` endpoint kept its own hardcoded gateway list in `internal/pinner/ipfs-node/legacy.go`:

```go
IPFS_HTTP_GATEWAYS = []string{
    "https://w3s.link/ipfs/%s",
    "https://dweb.link/ipfs/%s",
    "https://ipfs.io/ipfs/%s",
}
```

So consumers still on `/get` (today: `refiner`, until very recently `bsp-agent`) were silently routed through `w3s.link` and saw it in the logs:

```
ewm-das  WARN  Deprecated endpoint accessed: /get
ewm-das  DEBUG ipfs-node/legacy.go:76  trying out https://w3s.link/ipfs/bafy...
```

This PR derives `IPFS_HTTP_GATEWAYS` from `gateway.DefaultGateways` at package init, so the legacy fetcher uses the same single source of truth as the `/api/v1/get` handler. The list now reads (post-#73):

```
https://ipfs.filebase.io/ipfs/%s
https://trustless-gateway.link/ipfs/%s
https://dweb.link/ipfs/%s
https://ipfs.io/ipfs/%s
```

## Design notes

- **Source of truth.** `gateway.DefaultGateways` is now the single place to update the pool. Future tweaks flow through both endpoint families automatically and the legacy path can never drift back to a retired gateway.
- **Format suffix.** The legacy fetcher uses `fmt.Sprintf` to inject the CID, so each base URL is suffixed with `/ipfs/%s` at init (`strings.TrimRight(g, "/") + "/ipfs/%s"`). The new path uses `url.Parse + path.Join` and doesn't need the suffix.
- **DEDICATED_GATEWAY intentionally not honoured here.** The legacy endpoint is deprecated. Consumers should migrate to `/api/v1/get` to pick up dedicated-gateway support *and* the new path's parallel-fetch worker pool. Keeping the legacy path "as good as new" would weaken the migration incentive.
- **No semantic change to the legacy fetcher.** It still returns raw IPFS bytes (vs the new path's DAS-decode + reconstruct). Only the gateway list changes.

## Version bump

`common/constants.go` is also bumped: `Version = "v0.18.1"` (was `"v0.1.0"`, a stale fallback). The Makefile injects `git describe --tags` via `ldflags` at build-time so this constant is only used when the binary is built without the Makefile path — but the fallback should still report a sensible post-#73 version.

## Test plan

- [x] Merge #73 first (this PR's base).
- [x] Rebuild `ewm-das:latest` from this branch.
- [ ] Re-run [`covalenthq/refiner` PR #292](https://github.com/covalenthq/refiner/pull/292) CI against the rebuilt image with `/get` still mapped — confirm no `w3s.link` line in the `ewm-das` logs.
- [ ] Hit `/get?cid=<known-good-cid>` against the rebuilt image directly — confirm it routes through `ipfs.filebase.io` first and returns the same bytes the old gateway list did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)